### PR TITLE
feat: short mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ You can find the built binaries [here](https://github.com/TheDevMinerTV/package-
 package-size-calculator
 ```
 
+The following additional flags are available:
+```
+--short    : Print a shorter version of the package report, ideal for posts to Twitter
+```
+
 ## License
 
 Package size calculator is licensed under the MIT License. See [LICENSE](LICENSE) for the full license text.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"package_size_calculator/internal/build"
 	"package_size_calculator/pkg/npm"
@@ -19,6 +20,8 @@ const (
 var (
 	npmClient *npm.Client
 	dockerC   *docker_client.Client
+
+	fShortMode = flag.Bool("short", false, "Print a shorter version of the package report, ideal for posts to Twitter")
 )
 
 func main() {
@@ -26,6 +29,8 @@ func main() {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	// zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	flag.Parse()
 
 	log.Info().Msgf("Package size calculator %s (%s, built on %s)", build.Version, build.Commit, build.BuildTime)
 


### PR DESCRIPTION
Short mode outputs a shorter version of the package report, ideal for posts to Twitter.

Fixes #10 
![Screenshot_20240716_203256](https://github.com/user-attachments/assets/d57e7777-d524-45fb-ace2-b8ac93829ced)
<small>Short mode for version comparison mode</small>

![Screenshot_20240716_203336](https://github.com/user-attachments/assets/bb51aa2e-4272-45ea-97b1-bc6af91013e9)
<small>Short mode for dependency replacement mode</small>