### PR TITLE
fix: subdependencies count is off by 1

### DIFF
--- a/pkg/npm/package_lock.go
+++ b/pkg/npm/package_lock.go
@@ -46,6 +46,9 @@ func (p *LockedPackages) UnmarshalJSON(data []byte) error {
 
 	*p = make(LockedPackages, len(packages))
 
+	// Remove the empty key, which is used to store the root package
+	delete(packages, "")
+
 	for name, pkg := range packages {
 		name := strings.TrimPrefix(name, "node_modules/")
 

--- a/version_size_diff.go
+++ b/version_size_diff.go
@@ -21,7 +21,7 @@ func calculateVersionSizeChange() {
 	reportPackageInfo(&pkg.New, false, 0)
 	fmt.Println()
 	reportSizeDifference(pkg.Old.Size, pkg.New.Size, pkg.Old.DownloadsLastWeek, pkg.New.TotalDownloads)
-	reportSubdependencies(len(pkg.Old.Lockfile.Packages), len(pkg.New.Lockfile.Packages))
+	reportSubdependencies(len(pkg.Old.Lockfile.Packages)-1, len(pkg.New.Lockfile.Packages))
 }
 
 func promptPackageVersions(npmClient *npm.Client, dockerC *docker_client.Client) *packageVersionsInfo {


### PR DESCRIPTION
It's off by 1 because the lockfile contains a key for the root package. this can be removed.

Fixes #19