### PR TITLE
fix(reports): unknown download counts should not result in 0 downloads

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,3 +69,11 @@ func runSelect(s *promptui.Select) (int, string, error) {
 func runPrompt(p *promptui.Prompt) (string, error) {
 	return p.Run()
 }
+
+func uint64Ptr(i uint64) *uint64 {
+	return &i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}

--- a/pkg/npm/download_counts.go
+++ b/pkg/npm/download_counts.go
@@ -25,8 +25,9 @@ func (n *Client) GetPackageDownloadsLastWeek(packageName string) (Downloads, err
 
 type Downloads map[string]uint64
 
-func (d Downloads) ForVersion(version string) uint64 {
-	return d[version]
+func (d Downloads) ForVersion(version string) (uint64, bool) {
+	count, ok := d[version]
+	return count, ok
 }
 
 func (d Downloads) Total() uint64 {


### PR DESCRIPTION
When NPM's API returns no results for a version, it got defaulted to 0. Now all calculations that use the version's download count show a N/A instead of a 0.

![image](https://github.com/user-attachments/assets/779fa0b1-62b8-42f3-826f-3417e853e362)

Fixes #20