### PR TITLE
fix(reports): no change in subdependencies should not be red

### DIFF
--- a/report.go
+++ b/report.go
@@ -288,10 +288,10 @@ func reportSizeDifference(oldSize uint64, newSize uint64, downloads *uint64, tot
 }
 
 func reportSubdependencies(oldSubdependencies, newSubdependencies int64) {
-	var indicatorColor *color.Color
+	indicatorColor := boldGray
 	if oldSubdependencies > newSubdependencies {
 		indicatorColor = boldGreen
-	} else {
+	} else if oldSubdependencies < newSubdependencies {
 		indicatorColor = boldRed
 	}
 	subdepsFmt := indicatorColor.Sprint(fmtInt(newSubdependencies))


### PR DESCRIPTION
Fixes this:
![image](https://github.com/user-attachments/assets/53f262da-6495-4e84-a6d0-ce27be48ffde)
