### PR TITLE
fix: display correct node version on download fail message

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 	log.Info().Msgf("Pulling %s image for measuring package sizes", BaseImage)
 	if err := downloadBaseImage(dockerC); err != nil {
-		log.Fatal().Err(err).Msg("Failed to download Node 20 image")
+		log.Fatal().Err(err).Msg("Failed to download Node 22 image")
 	}
 
 	variant, _, err := runSelect(&promptui.Select{


### PR DESCRIPTION
forgot to start docker, saw this message