### PR TITLE
fix: off by one during subdependencies calculation

### DIFF
--- a/dependency_change.go
+++ b/dependency_change.go
@@ -56,7 +56,7 @@ func replaceDeps() {
 			if err != nil {
 				l.Error().Err(err).Msg("Failed to parse package-lock.json")
 			} else {
-				dep.Subdependencies = uint64(len(lock.Packages))
+				dep.Subdependencies = getSubdependenciesCount(lock)
 			}
 
 			l.Info().Msgf("Package size: %s", humanize.Bytes(dep.Size))
@@ -254,7 +254,7 @@ func promptPackage(npmClient *npm.Client, dockerC *docker_client.Client) *packag
 		TotalDownloads:    downloads.Total(),
 		DownloadsLastWeek: downloadsLastWeek,
 		Size:              size,
-		Subdependencies:   uint64(len(b.Lockfile.Packages)),
+		Subdependencies:   getSubdependenciesCount(b.Lockfile),
 	}.Calculate()
 
 	return b
@@ -359,4 +359,10 @@ func (s calculatedStats) FormattedSubdependencies() string {
 
 func calculatePercentage(part, total float64) float64 {
 	return 100 * part / total
+}
+
+func getSubdependenciesCount(lock *npm.PackageLockJSON) uint64 {
+	// We need to subtract by 1 because the installed package is included in
+	// the lockfile, which we only want the subdependencies
+	return uint64(len(lock.Packages) - 1)
 }

--- a/report.go
+++ b/report.go
@@ -33,7 +33,7 @@ func printReport(
 	packageJson := package_.JSON
 	downloadsLastWeek := modifiedPackage.Stats.DownloadsLastWeek
 	oldPackageSize := modifiedPackage.Stats.Size
-	oldSubdependencies := uint64(len(modifiedPackage.Lockfile.Packages))
+	oldSubdependencies := getSubdependenciesCount(modifiedPackage.Lockfile)
 
 	modifiedPackageName := boldYellow.Sprint(packageJson.String())
 
@@ -43,10 +43,16 @@ func printReport(
 	for _, p := range deps {
 		if p.Type == DependencyRemoved {
 			newPackageSize -= p.Size
-			newSubdependencies -= p.Subdependencies
 			packageSizeWithoutRemovedDeps -= p.Size
+			// This package
+			newSubdependencies -= 1
+			// It's subdependencies
+			newSubdependencies -= p.Subdependencies
 		} else {
 			newPackageSize += p.Size
+			// This package
+			newSubdependencies += 1
+			// It's subdependencies
 			newSubdependencies += p.Subdependencies
 		}
 	}

--- a/version_size_diff.go
+++ b/version_size_diff.go
@@ -115,7 +115,7 @@ func promptPackageVersions(npmClient *npm.Client, dockerC *docker_client.Client)
 			log.Fatal().Err(err).Msg("Failed to parse old package-lock.json")
 		}
 
-		oldStats.Subdependencies = uint64(len(b.Old.Lockfile.Packages))
+		oldStats.Subdependencies = getSubdependenciesCount(b.Old.Lockfile)
 	}()
 
 	go func() {
@@ -131,7 +131,7 @@ func promptPackageVersions(npmClient *npm.Client, dockerC *docker_client.Client)
 			log.Fatal().Err(err).Msg("Failed to parse new package-lock.json")
 		}
 
-		newStats.Subdependencies = uint64(len(b.New.Lockfile.Packages))
+		newStats.Subdependencies = getSubdependenciesCount(b.New.Lockfile)
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
Fixes that "sucrase@3.35.0" with "glob@10.4.5" removed and "fdir@6.1.1" and "picomatch@3.0.1" results in 17 subdeps, but in 16.

I wasn't accounting for the package itself being in the lockfile. I also wasn't calculating in the removed and added packages itself in the modified package.