### PR TITLE
fix: actually use `npm install` to resolve the package modifications

### DIFF
--- a/internal/fs.go
+++ b/internal/fs.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,4 +37,17 @@ func SanetizeFileName(path string) string {
 	path = strings.ReplaceAll(path, "|", "_")
 
 	return path
+}
+
+func WriteJSONFile(path string, content any) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(content)
 }

--- a/package.go
+++ b/package.go
@@ -12,7 +12,7 @@ import (
 func measurePackageSize(dockerC *docker_client.Client, package_ npm.DependencyInfo) (uint64, internal.TmpDir, error) {
 	l := log.With().Str("package", package_.String()).Logger()
 
-	tmpDir, err := installPackageInContainer(dockerC, package_)
+	tmpDir, err := installPackageInContainer(package_)
 	if err != nil {
 		return 0, tmpDir, errors.Wrapf(err, "failed to install package \"%s\"", package_.String())
 	}

--- a/pkg/npm/package_json.go
+++ b/pkg/npm/package_json.go
@@ -72,6 +72,27 @@ func (d PackageDependencies) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
+func (d *PackageDependencies) Remove(toRemove DependencyInfo) bool {
+	if _, ok := (*d)[toRemove.Name]; !ok {
+		return false
+	}
+
+	delete(*d, toRemove.Name)
+
+	return true
+}
+
+func (d *PackageDependencies) Add(toAdd DependencyInfo) error {
+	dep, err := newDependency(toAdd.Name, toAdd.Version)
+	if err != nil {
+		return err
+	}
+
+	(*d)[toAdd.Name] = dep
+
+	return nil
+}
+
 type Dependency struct {
 	Name          string
 	RawConstraint string


### PR DESCRIPTION
With this we're finally counting deduplicated dependencies correctly, which also **makes all previous reports invalid**.

Fixes #33 with the result:
```
Package info for "conventional-changelog-core@8.0.0": 7.7 MB
  Released: 2024-05-03 22:57:39.316 +0000 UTC (11w ago)
  Downloads last week: 29,915 (1.31%)
  Estimated traffic last week: 230 GB
  Subdependencies: 45

Removed dependencies:
  - read-package-up@11.0.0: 1.7 MB (21.52%)
    Downloads last week: 552,639 (N/A% from 11.0.0)
    Downloads last week from "conventional-changelog-core@8.0.0": 29,915 (N/A%)
    Traffic last week: N/A
    Traffic from "conventional-changelog-core@8.0.0": 230 GB (N/A%)
    Subdependencies: 28 (62.22%)
  - read-pkg@9.0.1: 1.6 MB (21.33%)
    Downloads last week: 908,007 (N/A% from 9.0.1)
    Downloads last week from "conventional-changelog-core@8.0.0": 29,915 (N/A%)
    Traffic last week: N/A
    Traffic from "conventional-changelog-core@8.0.0": 230 GB (N/A%)
    Subdependencies: 26 (57.77%)

Added dependencies:
  + fd-package-json@1.2.0: 20 kB (0.25%)
    Downloads last week: 594,609 (N/A% from 1.2.0)
    Estimated traffic last week: N/A
    Subdependencies: 1 (2.22%)

Estimated new statistics:
  Package size: 7.7 MB → 7.0 MB (91.75%)
  Subdependencies: 45 → 27 (-18)
  Traffic with last week's downloads:
    For current version: 230 GB → 211 GB (19 GB saved)
    For all versions: 18 TB → 16 TB (1.4 TB saved)
```